### PR TITLE
Fix author profile page link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Simple flask based web server for submitting APK files and getting them analysed. 
 This flask app uses a small sqlite3 DB to cache already analysed results.
 
-Author: [aaron kaplan](github.com/aaronkaplan)
+Author: [aaron kaplan](https://github.com/aaronkaplan)
 
 
 # How to run this program?


### PR DESCRIPTION
Just prefix `https://` to the GitHub URL so that the GitHub Markdown parser doesn't think the link refers to a document inside the current repo...